### PR TITLE
Added support for stack lts-3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-3.10
+packages:
+- '.'
+extra-deps: []
+flags: {}

--- a/taglib-api.cabal
+++ b/taglib-api.cabal
@@ -35,9 +35,9 @@ library
   build-depends:       base         >= 4    && < 5    ,
                        bytestring   >= 0.9  && < 0.11 ,
                        containers   >= 0.5  && < 0.6  ,
-                       mtl          >= 2.1  && < 2.2  ,
-                       text         >= 0.11 && < 0.12 ,
-                       transformers >= 0.2  && < 0.4
+                       mtl          >= 2.1  && < 2.3 ,
+                       text         >= 0.11 && < 1.3 ,
+                       transformers >= 0.2  && < 0.5
   hs-source-dirs:      src
 
   default-language:    Haskell2010


### PR DESCRIPTION
I've relaxed the requirements so it's compatible with a recent stack LTS release and added a simple stack.yaml

It still compiles (which surprised me given the huge leap in the version number of text), but I haven't gotten around to playing with it yet.
